### PR TITLE
Update version suffix and add xlrd requirement

### DIFF
--- a/tools/xls2tsv/xlsx2tsv.xml
+++ b/tools/xls2tsv/xlsx2tsv.xml
@@ -2,11 +2,12 @@
     <description>with pandas</description>
     <macros>
         <token name="@TOOL_VERSION@">0.2.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="2.2.1">pandas</requirement>
         <requirement type="package" version="3.1.5">openpyxl</requirement>
+        <requirement type="package" version="2.0.1">xlrd</requirement>
     </requirements>
     <command detect_errors="aggressive"><![CDATA[
     mkdir output;


### PR DESCRIPTION
We have a use case with xls

```
Failed to convert to TSV from /data/dnb12/galaxy_db/files/8/3/3/dataset_833f5510-a30d-45c3-be9f-75e5ea1f6360.dat: Missing optional dependency 'xlrd'. Install xlrd >= 2.0.1 for xls Excel support Use pip or conda to install xlrd.
```

ping @bernt-matthias 